### PR TITLE
Fixed issue where config files weren't being named properly

### DIFF
--- a/lib/capistrano/cookbook/helpers/setup_config_values.rb
+++ b/lib/capistrano/cookbook/helpers/setup_config_values.rb
@@ -19,19 +19,19 @@ module Capistrano
         [
           {
             source: "nginx.conf",
-            link: "/etc/nginx/sites-enabled/{{full_app_name}}"
+            link: "/etc/nginx/sites-enabled/#{fetch(:full_app_name)}"
           },
           {
             source: "unicorn_init.sh",
-            link: "/etc/init.d/unicorn_{{full_app_name}}"
+            link: "/etc/init.d/unicorn_#{fetch(:full_app_name)}"
           },
           {
             source: "log_rotation",
-           link: "/etc/logrotate.d/{{full_app_name}}"
+           link: "/etc/logrotate.d/#{fetch(:full_app_name)}"
           },
           {
             source: "monit",
-            link: "/etc/monit/conf.d/{{full_app_name}}.conf"
+            link: "/etc/monit/conf.d/#{fetch(:full_app_name)}.conf"
           }
         ]
       end


### PR DESCRIPTION
This gem is great but I had an issue where the `ln -s` command would either fail or overwrite a file because it was being called the name of the source instead of the `full_app_name`. This fixes it :)