### PR TITLE
database:create task will work if ssh is on a port other than 22

### DIFF
--- a/lib/capistrano/cookbook/tasks/create_database.cap
+++ b/lib/capistrano/cookbook/tasks/create_database.cap
@@ -7,7 +7,7 @@ namespace :database do
       unless test("[ -f #{shared_path}/config/database.yml ]")
         execute "cp #{shared_path}/config/database.example.yml #{shared_path}/config/database.yml"
       end
-      system("scp #{fetch(:deploy_user)}@#{host}:#{shared_path}/config/database.yml db.tmp.yml")
+      system("scp -P #{host.port or 22} #{fetch(:deploy_user)}@#{host}:#{shared_path}/config/database.yml db.tmp.yml")
       yaml =  YAML.load_file("db.tmp.yml")
       system("rm db.tmp.yml")
       puts yaml


### PR DESCRIPTION
I faced an issue while trying to use this cookbook on vagrant. in my case vagrant was using port 2222 for ssh which broke the scp call to copy the database.yml. I just added the port parameter to fix this issue.
