### PR TITLE
Changed method name which deprecated in Ruby 3.2

### DIFF
--- a/lib/capistrano/cookbook/tasks/setup_config.cap
+++ b/lib/capistrano/cookbook/tasks/setup_config.cap
@@ -32,7 +32,7 @@ namespace :deploy do
       #   sudo "ln -nfs #{shared_path}/config/#{symlink[:source]} #{sub_strings(symlink[:link])}"
       # end
 
-      if File.exists?(File.join('config', 'master.key'))
+      if File.exist?(File.join('config', 'master.key'))
         upload! File.join('config', 'master.key'), File.join(shared_path, 'config', 'master.key')
       end
     end


### PR DESCRIPTION
In ruby 3.2.0 `File.exists?` was deprecated. 